### PR TITLE
feat(horse-race): add foundation for Horse Race mini-game (models + API setup)

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
+        <option name="gradleJvm" value="ms-21" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="ms-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/app/src/test/java/com/example/mankomaniaclient/api/RaceResultTest.kt
+++ b/app/app/src/test/java/com/example/mankomaniaclient/api/RaceResultTest.kt
@@ -30,3 +30,5 @@ class RaceResultTest {
         assertEquals(0, result.amountWon)
     }
 }
+W
+

--- a/app/app/src/test/java/com/example/mankomaniaclient/api/RaceResultTest.kt
+++ b/app/app/src/test/java/com/example/mankomaniaclient/api/RaceResultTest.kt
@@ -1,0 +1,32 @@
+package com.example.mankomaniaclient.api
+
+import com.google.gson.Gson
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class RaceResultTest {
+
+    private val gson = Gson()
+
+    @Test
+    fun testRaceResultSerialization() {
+        val result = RaceResult(winningHorseId = 1, playerWon = true, amountWon = 500)
+        val json = gson.toJson(result)
+
+        assertTrue(json.contains("\"winningHorseId\":1"))
+        assertTrue(json.contains("\"playerWon\":true"))
+        assertTrue(json.contains("\"amountWon\":500"))
+    }
+
+    @Test
+    fun testRaceResultDeserialization() {
+        val json = """{"winningHorseId":2,"playerWon":false,"amountWon":0}"""
+        val result = gson.fromJson(json, RaceResult::class.java)
+
+        assertEquals(2, result.winningHorseId)
+        assertFalse(result.playerWon)
+        assertEquals(0, result.amountWon)
+    }
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -119,6 +119,8 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.constraintlayout)
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.squareup.retrofit2:converter-gson:2.9.0")
     testImplementation(libs.junit)
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,6 +121,9 @@ dependencies {
     implementation(libs.androidx.constraintlayout)
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.0")
+    testImplementation("org.junit.platform:junit-platform-launcher:1.10.0")
     testImplementation(libs.junit)
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)
@@ -130,4 +133,5 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+    implementation(kotlin("test"))
 }

--- a/app/src/main/java/com/example/mankomaniaclient/api/Horse.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/api/Horse.kt
@@ -1,0 +1,7 @@
+package com.example.mankomaniaclient.api
+
+data class Horse(
+    val id: Int,
+    val name: String,
+    val color: String
+)

--- a/app/src/main/java/com/example/mankomaniaclient/api/HorseRaceApi.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/api/HorseRaceApi.kt
@@ -1,4 +1,17 @@
 package com.example.mankomaniaclient.api
 
-class HorseRaceApi {
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface HorseRaceApi {
+    @GET("horses")
+    suspend fun getHorses(): List<Horse>
+
+    @POST("select")
+    suspend fun selectHorse(@Body request: HorseSelectionRequest): Response<Unit>
+
+    @GET("race/result")
+    suspend fun getRaceResult(): RaceResult
 }

--- a/app/src/main/java/com/example/mankomaniaclient/api/HorseRaceApi.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/api/HorseRaceApi.kt
@@ -1,0 +1,4 @@
+package com.example.mankomaniaclient.api
+
+class HorseRaceApi {
+}

--- a/app/src/main/java/com/example/mankomaniaclient/api/HorseSelectionRequest.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/api/HorseSelectionRequest.kt
@@ -1,4 +1,6 @@
 package com.example.mankomaniaclient.api
 
-class HorseSelectionRequest {
-}
+data class HorseSelectionRequest(
+    val playerId: String,
+    val horseId: Int
+)

--- a/app/src/main/java/com/example/mankomaniaclient/api/HorseSelectionRequest.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/api/HorseSelectionRequest.kt
@@ -1,0 +1,4 @@
+package com.example.mankomaniaclient.api
+
+class HorseSelectionRequest {
+}

--- a/app/src/main/java/com/example/mankomaniaclient/api/RaceResult.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/api/RaceResult.kt
@@ -1,4 +1,7 @@
 package com.example.mankomaniaclient.api
 
-class RaceResult {
-}
+data class RaceResult(
+    val winningHorseId: Int,
+    val playerWon: Boolean,
+    val amountWon: Int
+)

--- a/app/src/main/java/com/example/mankomaniaclient/api/RaceResult.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/api/RaceResult.kt
@@ -1,0 +1,4 @@
+package com.example.mankomaniaclient.api
+
+class RaceResult {
+}

--- a/app/src/test/java/com/example/mankomaniaclient/api/HorseSelectionRequestTest.kt
+++ b/app/src/test/java/com/example/mankomaniaclient/api/HorseSelectionRequestTest.kt
@@ -1,0 +1,28 @@
+package com.example.mankomaniaclient.api
+
+import com.google.gson.Gson
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class HorseSelectionRequestTest {
+
+    private val gson = Gson()
+
+    @Test
+    fun testHorseSelectionRequestSerialization() {
+        val request = HorseSelectionRequest(playerId = "player-001", horseId = 2)
+        val json = gson.toJson(request)
+
+        assertTrue(json.contains("\"playerId\":\"player-001\""))
+        assertTrue(json.contains("\"horseId\":2"))
+    }
+
+    @Test
+    fun testHorseSelectionRequestDeserialization() {
+        val json = """{"playerId":"player-001","horseId":2}"""
+        val request = gson.fromJson(json, HorseSelectionRequest::class.java)
+
+        assertEquals("player-001", request.playerId)
+        assertEquals(2, request.horseId)
+    }
+}

--- a/app/src/test/java/com/example/mankomaniaclient/api/HorseTest.kt
+++ b/app/src/test/java/com/example/mankomaniaclient/api/HorseTest.kt
@@ -1,0 +1,33 @@
+package com.example.mankomaniaclient.api
+
+import com.google.gson.Gson
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HorseTest {
+
+    private val gson = Gson()
+
+    @Test
+    fun testHorseSerialization() {
+        val horse = Horse(id = 1, name = "Horse 1", color = "blue")
+        val json = gson.toJson(horse)
+
+        println("Serialized JSON: $json")
+
+        assertTrue(json.contains("\"id\":1"))
+        assertTrue(json.contains("\"name\":\"Horse 1\""))
+        assertTrue(json.contains("\"color\":\"blue\""))
+    }
+
+    @Test
+    fun testHorseDeserialization() {
+        val json = """{"id":2,"name":"Horse 2","color":"red"}"""
+        val horse = gson.fromJson(json, Horse::class.java)
+
+        assertEquals(2, horse.id)
+        assertEquals("Horse 2", horse.name)
+        assertEquals("red", horse.color)
+    }
+}

--- a/app/src/test/java/com/example/mankomaniaclient/api/RaceResultTest.kt
+++ b/app/src/test/java/com/example/mankomaniaclient/api/RaceResultTest.kt
@@ -1,4 +1,32 @@
 package com.example.mankomaniaclient.api
 
+import com.google.gson.Gson
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
 class RaceResultTest {
+
+    private val gson = Gson()
+
+    @Test
+    fun testRaceResultSerialization() {
+        val result = RaceResult(winningHorseId = 1, playerWon = true, amountWon = 500)
+        val json = gson.toJson(result)
+
+        assertTrue(json.contains("\"winningHorseId\":1"))
+        assertTrue(json.contains("\"playerWon\":true"))
+        assertTrue(json.contains("\"amountWon\":500"))
+    }
+
+    @Test
+    fun testRaceResultDeserialization() {
+        val json = """{"winningHorseId":2,"playerWon":false,"amountWon":0}"""
+        val result = gson.fromJson(json, RaceResult::class.java)
+
+        assertEquals(2, result.winningHorseId)
+        assertFalse(result.playerWon)
+        assertEquals(0, result.amountWon)
+    }
 }

--- a/app/src/test/java/com/example/mankomaniaclient/api/RaceResultTest.kt
+++ b/app/src/test/java/com/example/mankomaniaclient/api/RaceResultTest.kt
@@ -1,0 +1,4 @@
+package com.example.mankomaniaclient.api
+
+class RaceResultTest {
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
 agp = "8.9.0"
 kotlin = "2.0.21"
-coreKtx = "1.15.0"
+coreKtx = "1.16.0"
 junit = "4.13.2"
-junitJupiterApi = "5.11.4"
+junitJupiterApi = "5.12.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
-krossbowStompCore = "7.0.0"
-krossbowWebsocketBuiltin = "7.0.0"
-krossbowWebsocketOkhttp = "7.0.0"
+krossbowStompCore = "9.3.0"
+krossbowWebsocketBuiltin = "9.3.0"
+krossbowWebsocketOkhttp = "9.3.0"
 lifecycleRuntimeKtx = "2.8.7"
 activityCompose = "1.10.1"
-composeBom = "2025.03.00"
+composeBom = "2025.04.00"
 constraintlayout = "2.2.1"
 
 

--- a/local.properties
+++ b/local.properties
@@ -4,5 +4,5 @@
 # Location of the SDK. This is only used by Gradle.
 # For customization when using a Version Control System, please read the
 # header note.
-#Sat Apr 05 14:11:49 CEST 2025
-sdk.dir=C\:\\Users\\annap\\AppData\\Local\\Android\\Sdk
+#Mon Apr 14 14:22:46 CEST 2025
+sdk.dir=/Users/valentinaschiavon/Library/Android/sdk


### PR DESCRIPTION
Initial setup for the Horse Race mini-game

Added:
- Horse.kt: Horse model with id, name, color
- RaceResult.kt: Server-side result of the race
- HorseSelectionRequest.kt: Selection data sent by the player
- HorseRaceApi.kt: Retrofit interface with backend endpoints
- Gradle dependencies for Retrofit and Gson
Ready for UI and game logic development in upcoming commits.
