### PR TITLE
chore(sonar): adjust SonarCloud configuration 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,8 +100,8 @@ sonar {
         property("sonar.projectKey", "mankomania_mankomania-client")
         property("sonar.organization", "mankomania-1")
         property("sonar.host.url", "https://sonarcloud.io")
-        property("sonar.sources", "src/main/kotlin")
-        property("sonar.tests", "src/test/kotlin")
+        property("sonar.sources", "src/main/java/com/example/mankomaniaclient")
+        property("sonar.tests", "src/test/java/com/example/mankomaniaclient")
         property("sonar.coverage.jacoco.xmlReportPaths", "${layout.buildDirectory.get().asFile}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
         property("sonar.exclusions", "**/build/**, **/generated/**, **/.idea/**, local.properties")
     }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,7 +100,10 @@ sonar {
         property("sonar.projectKey", "mankomania_mankomania-client")
         property("sonar.organization", "mankomania-1")
         property("sonar.host.url", "https://sonarcloud.io")
+        property("sonar.sources", "src/main/kotlin")
+        property("sonar.tests", "src/test/kotlin")
         property("sonar.coverage.jacoco.xmlReportPaths", "${layout.buildDirectory.get().asFile}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
+        property("sonar.exclusions", "**/build/**, **/generated/**, **/.idea/**, local.properties")
     }
 }
 


### PR DESCRIPTION
chore(sonar): adjust SonarCloud configuration for production code analysis

- Set sonar.sources to src/main/kotlin and sonar.tests to src/test/kotlin
- Add sonar.exclusions for build directories, generated files, IDE configuration files, and local properties
(- Update sonar.coverage.jacoco.xmlReportPaths to use the correct Jacoco XML report location)

This configuration change ensures that SonarCloud analyzes only the productive code, excluding build artifacts and configuration files.

✅ Note: The changes have been tested locally, to ensure a clean working tree and up-to-date integration before creating this pull request, using:
./gradlew testDebugUnitTest      # All tests passed
./gradlew jacocoTestReport        # Jacoco report generated successfully
git pull origin main                       # Confirmed the branch is up to date

