### PR TITLE
Fix/lobby4player

### DIFF
--- a/app/src/main/java/com/example/mankomaniaclient/JoinLobbyActivity.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/JoinLobbyActivity.kt
@@ -53,6 +53,7 @@ class JoinLobbyActivity : ComponentActivity() {
                                     Toast.LENGTH_SHORT
                                 ).show()
                                 hasAttemptedJoin.value = false
+                                webSocketService.clearLobbyResponse()
                             }
                         }
                     }

--- a/app/src/main/java/com/example/mankomaniaclient/JoinLobbyActivity.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/JoinLobbyActivity.kt
@@ -28,9 +28,10 @@ class JoinLobbyActivity : ComponentActivity() {
             val context = LocalContext.current
             val lobbyResponse by webSocketService.lobbyResponse.collectAsState(initial = null)
             val hasNavigated = remember { mutableStateOf(false) }
+            val hasAttemptedJoin = remember { mutableStateOf(false) }
 
-            LaunchedEffect(lobbyResponse) {
-                if (!hasNavigated.value) {
+            LaunchedEffect(lobbyResponse, hasAttemptedJoin.value) {
+                if (hasAttemptedJoin.value && !hasNavigated.value) {
                     lobbyResponse?.let { response ->
                         when (response.type) {
                             "joined" -> {
@@ -51,6 +52,7 @@ class JoinLobbyActivity : ComponentActivity() {
                                     "Join failed – Lobby does not exist!",
                                     Toast.LENGTH_SHORT
                                 ).show()
+                                hasAttemptedJoin.value = false
                             }
                         }
                     }
@@ -61,6 +63,7 @@ class JoinLobbyActivity : ComponentActivity() {
             JoinLobbyScreen(
                 playerName = playerName,
                 onJoinLobby = { lobbyId ->
+                    hasAttemptedJoin.value = true
                     webSocketService.joinLobby(lobbyId, playerName)
                 }
             )

--- a/app/src/main/java/com/example/mankomaniaclient/JoinLobbyActivity.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/JoinLobbyActivity.kt
@@ -35,15 +35,13 @@ class JoinLobbyActivity : ComponentActivity() {
                     lobbyResponse?.let { response ->
                         when (response.type) {
                             "joined" -> {
-                                if (!hasNavigated.value) {
-                                    hasNavigated.value = true
-                                    val intent =
-                                        Intent(context, CreateLobbyActivity::class.java).apply {
-                                            putExtra("playerName", playerName)
-                                            putExtra("lobbyId", response.lobbyId)
-                                        }
-                                    context.startActivity(intent)
-                                }
+                                hasNavigated.value = true
+                                val intent =
+                                    Intent(context, CreateLobbyActivity::class.java).apply {
+                                        putExtra("playerName", playerName)
+                                        putExtra("lobbyId", response.lobbyId)
+                                    }
+                                context.startActivity(intent)
                             }
 
                             "join-failed" -> {
@@ -65,6 +63,7 @@ class JoinLobbyActivity : ComponentActivity() {
                 playerName = playerName,
                 onJoinLobby = { lobbyId ->
                     hasAttemptedJoin.value = true
+                    webSocketService.clearLobbyResponse()
                     webSocketService.joinLobby(lobbyId, playerName)
                 }
             )

--- a/app/src/main/java/com/example/mankomaniaclient/LoadingActivity.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/LoadingActivity.kt
@@ -27,7 +27,7 @@ class LoadingActivity : ComponentActivity() {
         Handler(Looper.getMainLooper()).postDelayed({
             startActivity(Intent(this, NameActivity::class.java))
             finish()
-        }, 5000) // 3 Sekunden Delay
+        }, 1000) // 1 Sekunden Delay
 
         setContent {
             LoadingScreen()
@@ -39,7 +39,6 @@ class LoadingActivity : ComponentActivity() {
 @Composable
 fun LoadingScreen() {
     Box(modifier = Modifier.fillMaxSize()) {
-        // Hintergrundbild
         Image(
             painter = painterResource(id = R.drawable.loading_screen),
             contentDescription = "Loading",
@@ -47,7 +46,6 @@ fun LoadingScreen() {
             modifier = Modifier.fillMaxSize()
         )
 
-        // Ladebalken zentriert am unteren Rand
         Column(
             modifier = Modifier
                 .fillMaxSize()

--- a/app/src/main/java/com/example/mankomaniaclient/network/WebSocketService.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/network/WebSocketService.kt
@@ -41,6 +41,9 @@ object WebSocketService {
     val clientCount: StateFlow<Int> = _clientCount.asStateFlow()
     private lateinit var gameViewModel: GameViewModel
 
+    fun clearLobbyResponse() {
+        _lobbyResponse.value = null
+    }
     fun setGameViewModel(vm: GameViewModel) {
         gameViewModel = vm
     }


### PR DESCRIPTION
This PR fixes broken lobby navigation in multiplayer flows and ensures clean game flow.  
Players now only transition to the lobby waiting screen if the server confirms a successful join via WebSocket.

This PR correlates with 
Server PR # 60
https://github.com/mankomania/mankomania-server/pull/60
