### PR TITLE
Fix direct navigation from lobby to GameBoard

### DIFF
--- a/app/src/main/java/com/example/mankomaniaclient/CreateLobbyActivity.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/CreateLobbyActivity.kt
@@ -61,8 +61,10 @@ class CreateLobbyActivity : ComponentActivity() {
             if (lobbyResponse?.type == "start") {
                 val players = WebSocketService.playersInLobby.value
                 val intent = Intent(context, GameActivity::class.java).apply {
-                    putExtra("lobbyId", finalLobbyId.value)
                     putStringArrayListExtra("playerNames", ArrayList(players))
+                    putExtra("lobbyId", finalLobbyId.value)
+                    putExtra(GameActivity.EXTRA_SCREEN, GameActivity.SCREEN_GAMEBOARD)
+
                 }
                 context.startActivity(intent)
                 (context as? ComponentActivity)?.finish()

--- a/app/src/main/java/com/example/mankomaniaclient/GameActivity.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/GameActivity.kt
@@ -35,6 +35,9 @@ class GameActivity : ComponentActivity() {
         val playerNames  = intent.getStringArrayListExtra("playerNames")
             ?: arrayListOf(singleName)
 
+        val lobbyId = intent.getStringExtra("lobbyId")
+            ?: throw IllegalStateException("Missing lobbyId in Intent")
+
         // Create ViewModel (lifecycle-aware, no extra Compose dependency)
         val gameViewModel = ViewModelProvider(this)[GameViewModel::class.java]
 
@@ -46,6 +49,7 @@ class GameActivity : ComponentActivity() {
                 setContent {
                     MaterialTheme {
                         GameBoardScreen(
+                            lobbyId = lobbyId,
                             playerNames = playerNames,
                             viewModel   = gameViewModel
                         )
@@ -74,6 +78,7 @@ class GameActivity : ComponentActivity() {
                                         "playerNames",
                                         ArrayList(playerNames)
                                     )
+                                    putExtra("lobbyId", lobbyId)
                                     putExtra(EXTRA_SCREEN, SCREEN_GAMEBOARD)
                                 }
                                 startActivity(next)

--- a/app/src/main/java/com/example/mankomaniaclient/GameActivity.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/GameActivity.kt
@@ -1,5 +1,6 @@
 package com.example.mankomaniaclient
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -15,41 +16,72 @@ import androidx.lifecycle.ViewModelProvider
  * @since 2025-05-13
  * @description
  *   Main entry point for the game UI.
- *   Shows a welcome screen first, then loads the game board when the user starts.
+ *   Routes between Welcome, Lottery (future), and the GameBoard.
  */
 class GameActivity : ComponentActivity() {
 
     companion object {
-        const val EXTRA_SCREEN    = "extra_screen"
-        const val SCREEN_WELCOME  = "welcome"
-        const val SCREEN_LOTTERY  = "lottery"
+        const val EXTRA_SCREEN     = "extra_screen"
+        const val SCREEN_WELCOME   = "welcome"
+        const val SCREEN_LOTTERY   = "lottery"
+        const val SCREEN_GAMEBOARD = "gameboard"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // Retrieve player name and lobby ID from the Intent (fallbacks)
-        val playerName = intent.getStringExtra("playerName") ?: "Unknown"
-        val lobbyId    = intent.getStringExtra("lobbyId")    ?: "???"
+        // Retrieve both single-name fallback and full list from Intent
+        val singleName   = intent.getStringExtra("playerName") ?: "Unknown"
+        val playerNames  = intent.getStringArrayListExtra("playerNames")
+            ?: arrayListOf(singleName)
 
-        // Create your ViewModel here (lifecycle‐aware, no extra Compose dependency)
+        // Create ViewModel (lifecycle-aware, no extra Compose dependency)
         val gameViewModel = ViewModelProvider(this)[GameViewModel::class.java]
 
-        setContent {
-            MaterialTheme {
-                WelcomeScreen(
-                    onStartGame = {
-                        // swap in the actual game board
-                        setContent {
-                            MaterialTheme {
-                                GameBoardScreen(
-                                    playerNames = listOf(playerName),   // <— hier Liste übergeben
-                                    viewModel   = gameViewModel
-                                )
-                            }
-                        }
+        // Decide which screen to show based on the EXTRA_SCREEN flag
+        when (intent.getStringExtra(EXTRA_SCREEN)) {
+
+            SCREEN_GAMEBOARD -> {
+                // Directly show the main GameBoard, using the full list!
+                setContent {
+                    MaterialTheme {
+                        GameBoardScreen(
+                            playerNames = playerNames,
+                            viewModel   = gameViewModel
+                        )
                     }
-                )
+                }
+            }
+
+            SCREEN_LOTTERY -> {
+                // Placeholder for future Lottery mini-game
+                setContent {
+                    MaterialTheme {
+                        // LotteryScreen(/* … */)
+                    }
+                }
+            }
+
+            else -> {
+                // Default: show WelcomeScreen, then navigate to GameBoard on start
+                setContent {
+                    MaterialTheme {
+                        WelcomeScreen(
+                            onStartGame = {
+                                // Restart this Activity with GAMEBOARD flag and full list
+                                val next = Intent(this, GameActivity::class.java).apply {
+                                    putStringArrayListExtra(
+                                        "playerNames",
+                                        ArrayList(playerNames)
+                                    )
+                                    putExtra(EXTRA_SCREEN, SCREEN_GAMEBOARD)
+                                }
+                                startActivity(next)
+                                finish()
+                            }
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/mankomaniaclient/network/WebSocketService.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/network/WebSocketService.kt
@@ -102,13 +102,6 @@ object WebSocketService {
                         }
                     }
                 }
-                launch {
-                    stomp.subscribeText("/topic/game/state").collect { json ->
-                        val state = jsonParser.decodeFromString<GameStateDto>(json)
-                        Log.d("Game", "Received game state: $state")
-                        gameViewModel.onGameState(state)
-                    }
-                }
 
                 launch{
                     stomp.subscribeText("/topic/player-moved").collect { json ->
@@ -197,6 +190,20 @@ object WebSocketService {
                 }
             } catch (e: Exception) {
                 Log.e("WebSocket", "Error in subscribeToLobby: ${e.message}")
+            }
+        }
+        // neuer Game-State subscription-Block
+        scope.launch {
+            try {
+                session
+                    ?.subscribeText("/topic/game/state")
+                    ?.collect { json ->
+                        val state = jsonParser.decodeFromString<GameStateDto>(json)
+                        Log.d("WebSocket", "Received game state: $state")
+                        gameViewModel.onGameState(state)
+                    }
+            } catch (e: Exception) {
+                Log.e("WebSocket", "Error subscribing to game state: ${e.message}")
             }
         }
     }

--- a/app/src/main/java/com/example/mankomaniaclient/network/WebSocketService.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/network/WebSocketService.kt
@@ -103,12 +103,13 @@ object WebSocketService {
                     }
                 }
                 launch {
-                    stomp.subscribeText("/topic/game").collect { json ->
+                    stomp.subscribeText("/topic/game/state").collect { json ->
                         val state = jsonParser.decodeFromString<GameStateDto>(json)
                         Log.d("Game", "Received game state: $state")
                         gameViewModel.onGameState(state)
                     }
                 }
+
                 launch{
                     stomp.subscribeText("/topic/player-moved").collect { json ->
                     val moveResult = jsonParser.decodeFromString<MoveResult>(json)

--- a/app/src/main/java/com/example/mankomaniaclient/ui/screens/GameBoardScreen.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/ui/screens/GameBoardScreen.kt
@@ -26,13 +26,20 @@ import androidx.compose.material3.Button
 import com.example.mankomaniaclient.ui.components.PlayerCharacterView
 
 @Composable
-fun GameBoardScreen(playerNames: List<String>,viewModel: GameViewModel) {
-    val board by viewModel.board.collectAsState()
+fun GameBoardScreen(lobbyId: String, playerNames: List<String>,viewModel: GameViewModel) {
 
-    // --- MoveResult dialog logic ---
+    // Subscribe to lobby updates when the screen is first displayed
+    LaunchedEffect(lobbyId) {
+        Log.d("GameBoardScreen", "Subscribing to lobby $lobbyId")
+        viewModel.subscribeToLobby(lobbyId)
+    }
+    // Collect state values
+    val board by viewModel.board.collectAsState()
+    val players by viewModel.players.collectAsState()
     val moveResult by viewModel.moveResult.collectAsState()
     var showDialog by remember { mutableStateOf(true) }
 
+    // Show move result dialog when a move occurs
     if (moveResult != null && showDialog) {
         AlertDialog(
             onDismissRequest = { showDialog = false },
@@ -53,11 +60,14 @@ fun GameBoardScreen(playerNames: List<String>,viewModel: GameViewModel) {
         )
     }
 
+    // Debug log board size
     Log.d("GameBoardScreen", "Board size=${board.size}")
+
+    // Fallback if board is empty
     if (board.isEmpty()) {
         Text("No cells received!")
+        return
     }
-    val players by viewModel.players.collectAsState()
 
     val sideCount = board.size / 4
     val bgColor = MaterialTheme.colorScheme.surfaceVariant   // << soft grey / blue by default
@@ -69,6 +79,7 @@ fun GameBoardScreen(playerNames: List<String>,viewModel: GameViewModel) {
             .padding(16.dp)
     ) {
         Text(
+            // Display player names at corners
             text = playerNames.getOrNull(0) ?: "",
             modifier = Modifier
                 .align(Alignment.TopStart)

--- a/app/src/main/java/com/example/mankomaniaclient/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/viewmodel/GameViewModel.kt
@@ -33,6 +33,18 @@ class GameViewModel : ViewModel() {
     private val _moveResult = MutableStateFlow<MoveResult?>(null)
     val moveResult: StateFlow<MoveResult?> = _moveResult
 
+    /**
+     * Subscribe to the given lobby via WebSocket.
+     * This will route incoming GameStateDto and MoveResults automatically
+     */
+    fun subscribeToLobby(lobbyId: String) {
+        WebSocketService.subscribeToLobby(lobbyId)
+    }
+
+    init {
+        // Register this ViewModel with the WebSocketService for callbacks
+        WebSocketService.setGameViewModel(this)
+    }
 
     /** Called by WebSocketService when a new GameStateDto arrives */
     fun onGameState(state: GameStateDto) {


### PR DESCRIPTION
This PR ensures that when a lobby reaches the required player count and “Start Game” is pressed, the app skips any intermediate screens and launches the GameBoardScreen immediately.
We had this issue, that after joining a lobby, the user was shown another "create player" screen, when clicking on "start game". 
With this PR this should be fixed. 