### PR TITLE
fix(client): subscribe to lobby-specific game state before sending start

### DIFF
--- a/app/src/main/java/com/example/mankomaniaclient/CreateLobbyActivity.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/CreateLobbyActivity.kt
@@ -105,6 +105,7 @@ class CreateLobbyActivity : ComponentActivity() {
 
             Button(
                 onClick = {
+                    WebSocketService.subscribeToLobby(lobbyId)
                     Log.d("LOBBY", "Trying to start game in $lobbyId by $playerName")
                     WebSocketService.startGame(lobbyId, playerName)
                 },

--- a/app/src/main/java/com/example/mankomaniaclient/GameActivity.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/GameActivity.kt
@@ -1,5 +1,5 @@
 package com.example.mankomaniaclient
-
+import com.example.mankomaniaclient.network.WebSocketService
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -40,6 +40,9 @@ class GameActivity : ComponentActivity() {
 
         // Create ViewModel (lifecycle-aware, no extra Compose dependency)
         val gameViewModel = ViewModelProvider(this)[GameViewModel::class.java]
+
+        WebSocketService.setGameViewModel(gameViewModel)
+        WebSocketService.subscribeToLobby(lobbyId)
 
         // Decide which screen to show based on the EXTRA_SCREEN flag
         when (intent.getStringExtra(EXTRA_SCREEN)) {

--- a/app/src/main/java/com/example/mankomaniaclient/network/WebSocketService.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/network/WebSocketService.kt
@@ -164,6 +164,7 @@ object WebSocketService {
     }
 
     fun startGame(lobbyId: String, playerName: String) {
+        subscribeToLobby(lobbyId)
         val message = LobbyMessage(
             type = "start",
             playerName = playerName,
@@ -171,7 +172,7 @@ object WebSocketService {
         )
         val json = jsonParser.encodeToString(LobbyMessage.serializer(), message)
 
-        send("/app/lobby", json)
+        send("/app/lobby", jsonParser.encodeToString(LobbyMessage.serializer(), message))
     }
 
     fun subscribeToLobby(lobbyId: String) {
@@ -196,7 +197,7 @@ object WebSocketService {
         scope.launch {
             try {
                 session
-                    ?.subscribeText("/topic/game/state")
+                    ?.subscribeText("/topic/game/state/$lobbyId")
                     ?.collect { json ->
                         val state = jsonParser.decodeFromString<GameStateDto>(json)
                         Log.d("WebSocket", "Received game state: $state")

--- a/app/src/main/java/com/example/mankomaniaclient/network/WebSocketService.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/network/WebSocketService.kt
@@ -171,14 +171,16 @@ object WebSocketService {
             lobbyId = lobbyId
         )
         val json = jsonParser.encodeToString(LobbyMessage.serializer(), message)
-
+        Log.d("WS-START", "Sending start for lobby $lobbyId by $playerName")
         send("/app/lobby", jsonParser.encodeToString(LobbyMessage.serializer(), message))
     }
 
     fun subscribeToLobby(lobbyId: String) {
         scope.launch {
             try {
-                session?.subscribeText("/topic/lobby/$lobbyId")?.collect { json ->
+                session
+                    ?.subscribeText("/topic/lobby/$lobbyId")
+                    ?.collect { json ->
                     val response = jsonParser.decodeFromString<LobbyResponse>(json)
                     Log.d("WebSocket", "Received lobby update (join): $response")
 
@@ -199,6 +201,7 @@ object WebSocketService {
                 session
                     ?.subscribeText("/topic/game/state/$lobbyId")
                     ?.collect { json ->
+                        Log.d("WS-STATE", "Got game state JSON: $json")
                         val state = jsonParser.decodeFromString<GameStateDto>(json)
                         Log.d("WebSocket", "Received game state: $state")
                         gameViewModel.onGameState(state)


### PR DESCRIPTION
This PR  is **work in progess** and the following change makes sure the client doesn’t miss the first game state update by:

- Setting the GameViewModel in WebSocketService before subscribing
- Subscribing to /topic/game/state/{lobbyId} instead of the generic topic
- Calling subscribeToLobby(lobbyId) before sending the “start” message in both CreateLobbyActivity and WebSocketService

Now MAYBE the game board will load correctly as soon as the game starts > we will see after testing