### PR TITLE
feat(game-start): client-side support for dynamic game start

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -147,6 +147,7 @@ dependencies {
     implementation(libs.krossbow.websocket.builtin)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)

--- a/app/src/main/java/com/example/mankomaniaclient/network/GameStartedDto.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/network/GameStartedDto.kt
@@ -1,0 +1,17 @@
+/**
+ * @file GameStartedDto.kt
+ * @author Angela Drucks
+ * @since 2025-05-27
+ * @description DTO sent by the server when a game session starts, containing
+ *              the game ID and the list of starting positions for every player.
+ */
+
+package com.example.mankomaniaclient.network
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GameStartedDto(
+    val gameId: String,
+    val startPositions: List<Int>
+)

--- a/app/src/main/java/com/example/mankomaniaclient/network/GameStartedDto.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/network/GameStartedDto.kt
@@ -13,5 +13,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class GameStartedDto(
     val gameId: String,
-    val startPositions: List<Int>
+    val startPositions: List<Int>,
+    val firstPlayerIndex: Int
 )

--- a/app/src/main/java/com/example/mankomaniaclient/network/LobbyMessage.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/network/LobbyMessage.kt
@@ -5,5 +5,6 @@ import kotlinx.serialization.Serializable
 data class LobbyMessage(
     val type: String,
     val playerName: String,
-    val lobbyId: String? = null
+    val lobbyId: String? = null,
+    val boardSize: Int? = null
 )

--- a/app/src/main/java/com/example/mankomaniaclient/ui/screens/CreateLobbyScreen.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/ui/screens/CreateLobbyScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import android.content.Intent
 import androidx.compose.ui.platform.LocalContext
+import com.example.mankomaniaclient.util.Constants.DEFAULT_BOARD_SIZE
 
 
 @Composable
@@ -46,7 +47,7 @@ fun CreateLobbyScreen(
 
         if (players.size >= 2) {
             Button(onClick = {
-                WebSocketService.startGame(lobbyId, playerName)
+                WebSocketService.startGame(lobbyId, playerName, DEFAULT_BOARD_SIZE)
             }) {
                 Text("Start Game")
             }

--- a/app/src/main/java/com/example/mankomaniaclient/util/Constants.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/util/Constants.kt
@@ -1,0 +1,9 @@
+// app/src/main/java/com/example/mankomaniaclient/util/Constants.kt
+package com.example.mankomaniaclient.util
+
+object Constants {
+
+
+    /** Default number of cells, if server says nothing different */
+    const val DEFAULT_BOARD_SIZE = 20
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ coroutines = "1.4.3"
 serialization = "1.6.3"
 appcompat = "1.6.1"
 composeCompiler = "1.5.3"
+lifecycleViewmodelCompose = "2.8.1"
 
 [libraries]
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junitJupiterApi" }
@@ -45,10 +46,12 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+
 


### PR DESCRIPTION
Adds the initial setup for the “start game” flow on the client. This PR is part of the end-to-end game-start feature and is still a work in progress.

Changes:

- build.gradle / libs.versions.toml
Added lifecycle-viewmodel-compose dependency

- Constants.kt
 Introduced DEFAULT_BOARD_SIZE = 20

- network
GameStartedDto: new DTO for server’s start signal (gameId, startPositions, firstPlayerIndex)
LobbyMessage: added optional boardSize parameter

- WebSocketService
Updated startGame(...) to accept and send boardSize
Added subscription & parsing for /topic/game/started → GameStartedDto

- UI / CreateLobby
Injected GameViewModel into CreateLobbyActivity & CreateLobbyScreen
Pass boardSize when calling startGame

- GameViewModel
Store local player name for turn determination
Handle onGameStarted(dto: GameStartedDto) to initialize player positions and set isPlayerTurn

