### PR TITLE
show active player and restrict dice roll to correct turn

### DIFF
--- a/app/src/main/java/com/example/mankomaniaclient/CreateLobbyActivity.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/CreateLobbyActivity.kt
@@ -62,6 +62,7 @@ class CreateLobbyActivity : ComponentActivity() {
                 val players = WebSocketService.playersInLobby.value
                 val intent = Intent(context, GameActivity::class.java).apply {
                     putStringArrayListExtra("playerNames", ArrayList(players))
+                    putExtra("playerName", playerName)
                     putExtra("lobbyId", finalLobbyId.value)
                     putExtra(GameActivity.EXTRA_SCREEN, GameActivity.SCREEN_GAMEBOARD)
 

--- a/app/src/main/java/com/example/mankomaniaclient/ui/screens/GameBoardContent.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/ui/screens/GameBoardContent.kt
@@ -715,7 +715,7 @@ fun GameBoardContent(
         ) {
             Button(
                 onClick = {val rolledNumber = (2..12).random()
-                    diceResultMessage = "$myName rolled $rolledNumber "
+                    diceResultMessage = "$myName rolled a $rolledNumber "
                     onRollDice()},
                 enabled = isPlayerTurn,
                 shape = RoundedCornerShape(30.dp),

--- a/app/src/main/java/com/example/mankomaniaclient/viewmodel/GameViewModel.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/viewmodel/GameViewModel.kt
@@ -61,6 +61,10 @@ class GameViewModel : ViewModel() {
         }
     }
 
+
+    fun updateGameState(gameState: GameStateDto) {
+        _isPlayerTurn.value = (gameState.currentTurnPlayerName == myPlayerName.value)
+    }
     /**
      * Subscribe to the given lobby via WebSocket.
      * This will route incoming GameStateDto and MoveResults automatically


### PR DESCRIPTION
When it’s your turn, the roll button is enabled and clickable.

When it’s not your turn, the button is disabled.

On click the Name of the Player and the dice result is displayed for the specific player 

this PR does not need a cooperate server PR (works with the current state of server main)