### PR TITLE
Feature/player move forward

### DIFF
--- a/app/src/main/java/com/example/mankomaniaclient/model/MoveResult.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/model/MoveResult.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class MoveResult(
+    val name: String,
     val newPosition: Int,
     val oldPosition: Int,
     val fieldType: String,

--- a/app/src/main/java/com/example/mankomaniaclient/ui/screens/GameBoardContent.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/ui/screens/GameBoardContent.kt
@@ -716,7 +716,7 @@ fun GameBoardContent(
             Button(
                 onClick = {val rolledNumber = (2..12).random()
                     diceResultMessage = "$myName rolled a $rolledNumber "
-                    onRollDice()},
+                    viewModel.moveCurrentPlayerBy(rolledNumber) },
                 enabled = isPlayerTurn,
                 shape = RoundedCornerShape(30.dp),
                 colors = ButtonDefaults.buttonColors(

--- a/app/src/main/java/com/example/mankomaniaclient/ui/screens/GameBoardScreen.kt
+++ b/app/src/main/java/com/example/mankomaniaclient/ui/screens/GameBoardScreen.kt
@@ -30,8 +30,14 @@ fun GameBoardScreen(
         Log.d("DEBUG", "→ 2. ViewModel setzen")
         WebSocketService.setGameViewModel(viewModel)
 
+        WebSocketService.subscribeToPlayerMoved(lobbyId) { moveResult ->
+            Log.d("PLAYER-MOVED", "Empfangen in GameBoard: $moveResult")
+            viewModel.onPlayerMoved(moveResult)
+        }
+
         Log.d("DEBUG", "→ 3. Lobby abonnieren")
         viewModel.subscribeToLobby(lobbyId)
+
     }
 
 

--- a/app/src/test/java/com/example/mankomaniaclient/MoverResultTest.kt
+++ b/app/src/test/java/com/example/mankomaniaclient/MoverResultTest.kt
@@ -21,11 +21,12 @@ class MoveResultTest {
     @Test
     fun testMoveResultSerializationRoundTrip() {
         val original = MoveResult(
+            name = "TestMove",
             newPosition = 5,
             oldPosition = 3,
             fieldType = "CasinoAction",
             fieldDescription = "Try your luck",
-            playersOnField = listOf("Toni", "Jorge")
+            playersOnField = listOf("Toni", "Jorge"),
         )
 
         val json = Json.encodeToString(original)

--- a/app/src/test/java/com/example/mankomaniaclient/viewmodel/GameViewModelTest.kt
+++ b/app/src/test/java/com/example/mankomaniaclient/viewmodel/GameViewModelTest.kt
@@ -77,6 +77,7 @@ class GameViewModelTest {
     fun testOnPlayerMovedUpdatesState() = runTest {
         val viewModel = GameViewModel()
         val result = com.example.mankomaniaclient.model.MoveResult(
+            name = "Anna",
             newPosition = 2,
             oldPosition = 0,
             fieldType = "PayFeeAction",


### PR DESCRIPTION
This PR introduces initial handling of player movement updates on the client side.
Updates:
Subscribes to /topic/{lobbyId}/player-moved to reflect moves from all players.

Integrates MoveResult handling in GameViewModel.

Updates UI via GameBoardScreen.kt and WebSocketService.kt.

⚠️ Status:
This version is work-in-progress and not fully functional yet. UI updates do not reflect consistently across all clients.

goes hand in hand with Server PR: hhttps://github.com/mankomania/mankomania-server/pull/73